### PR TITLE
Updated Google API version to support table decoorators

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,8 +56,9 @@ lazy val sparkDependencies = Def.setting(Seq(
 
 // Dependencies which need to be shaded to run on Google Cloud Dataproc
 lazy val dependenciesToShade = Seq(
-  "com.google.cloud" % "google-cloud-bigquery" % "1.37.1" excludeAll(exclusions: _*),
-  "com.google.cloud.bigdataoss" % "gcs-connector" % "1.9.3-hadoop2" excludeAll(exclusions: _*)
+  "com.google.cloud" % "google-cloud-bigquery" % "1.63.0" excludeAll(exclusions: _*),
+  "com.google.cloud.bigdataoss" % "gcs-connector" % "1.9.3-hadoop2" excludeAll(exclusions: _*),
+  "com.google.http-client" % "google-http-client-apache" % "2.0.0" excludeAll(exclusions: _*)
 )
 
 // Dependencies which don't need any shading

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0"
+version in ThisBuild := "0.1.1"


### PR DESCRIPTION
 Updated Google API version to support table decoorators
eg. myProject.myDataset.myTable$myPartition

Without this change we encounter:
shadegoogle.cloud.bigquery.BigQueryException: Invalid table ID "myTable$myPartition". Table IDs must be alphanumeric (plus underscores) and must be at most 1024 characters long. Also, Table decorators cannot be used.