### PR TITLE
Deprecate spark-bigquery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# spark-bigquery: A Google BigQuery Data Source for Apache Spark
+# [DEPRECATED] spark-bigquery: A Google BigQuery Data Source for Apache Spark
+
+## Deprecation Notice
+
+This project has been deprecated in favor of the official
+[Apache Spark SQL connector for Google BigQuery](https://github.com/GoogleCloudDataproc/spark-bigquery-connector).
+
+
+## Overview
 
 This project provides a [Google BigQuery](https://cloud.google.com/bigquery/) data source (`com.miraisolutions.spark.bigquery.DefaultSource`) to [Apache Spark](https://spark.apache.org/) using the new [Google Cloud client libraries](https://cloud.google.com/bigquery/docs/reference/libraries) for the Google BigQuery API. It supports "direct" import/export where records are directly streamed from/to BigQuery. In addition, data may be imported/exported via intermediate data extracts on [Google Cloud Storage](https://cloud.google.com/storage/) (GCS). Note that when using "direct" (streaming) export, data may not be immediately available for further querying/processing in BigQuery. It may take several minutes for streamed records to become "available". See the following resources for more information:
 


### PR DESCRIPTION
This is to deprecate the spark-bigquery in favor of the official Apache Spark SQL connector for Google BigQuery (https://github.com/GoogleCloudDataproc/spark-bigquery-connector)